### PR TITLE
Update cluster_install_spack.sh before breaking change

### DIFF
--- a/pc_setup_scripts/pcluster_install_spack.sh
+++ b/pc_setup_scripts/pcluster_install_spack.sh
@@ -164,6 +164,7 @@ download_packages_yaml() {
 
 set_pcluster_defaults() {
     # Set versions of pre-installed software in packages.yaml
+    [ -z "${SLURM_ROOT}" ] && SLURM_ROOT="/opt/slurm"
     [ -z "${SLURM_VERSION}" ] && SLURM_VERSION=$(strings /opt/slurm/lib/libslurm.so | grep  -e '^VERSION'  | awk '{print $2}'  | sed -e 's?"??g')
     [ -z "${LIBFABRIC_MODULE_VERSION}" ] && LIBFABRIC_MODULE_VERSION=$(grep 'Version:' /opt/amazon/efa/lib64/pkgconfig/libfabric.pc | awk '{print $2}')
     [ -z "${LIBFABRIC_MODULE}" ] && LIBFABRIC_MODULE="libfabric-aws/${LIBFABRIC_MODULE_VERSION}"


### PR DESCRIPTION
This script pulls the packages-*.yaml files from the original https://github.com/spack/spack-configs location. PR https://github.com/spack/spack-configs/pull/82 introduces a breaking change since variable SLURM_ROOT is introduced in postinstall.sh and packages-*.yaml. This PR updates your script to match the new one.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
